### PR TITLE
chore: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   dependabot:
     name: Auto Merge
-    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v12.0.1
+    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@963c984dde02b0a8711f0d098aa9f8a7f2e50bca # v12.0.1
     with:
       force: true
     secrets:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
-        uses: cla-assistant/github-action@v2.6.1
+        uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OSS_CONTRIBUTOR_LICENSE_AGREEMENT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   update_release_draft:
     name: Update Release
-    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v9.2.0
+    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@e8d36c170846689fb7c63b03edd1eaba64dea3c4 # v9.2.0
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -78,12 +78,12 @@ runs:
         fi
 
     - name: Setup Node
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '22'
 
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references from version tags to full commit SHAs for improved supply chain security
- Prevents potential tag manipulation attacks by referencing immutable commit hashes
- Original version tags are preserved as inline comments for readability

### Pinned Actions

| Action | Version | SHA |
|---|---|---|
| `Staffbase/gha-workflows` (automerge) | v12.0.1 | `963c984d` |
| `Staffbase/gha-workflows` (release) | v9.2.0 | `e8d36c17` |
| `cla-assistant/github-action` | v2.6.1 | `ca4a40a7` |
| `actions/setup-node` | v5 | `a0853c24` |
| `actions/setup-python` | v6 | `a309ff8b` |

---
<sub>The changes and the PR were generated by OpenCode.</sub>