### PR TITLE
fix: add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,9 @@ name: Dependabot
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   dependabot:
     name: Auto Merge

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened, closed, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   update_release_draft:
     name: Update Release


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Add explicit `permissions` blocks to all three GitHub Actions workflow files to resolve open code scanning alerts ([`actions/missing-workflow-permissions`](https://github.com/Staffbase/backstage-techdocs-action/security/code-scanning), alerts #3, #12, #14).

Without an explicit `permissions` block, workflows inherit the default repository token permissions, which may be overly broad. This change follows the **principle of least privilege** by declaring only the minimum permissions each workflow needs:

| Workflow | Permissions | Rationale |
|---|---|---|
| `release.yml` | `contents: write` | Release drafter needs write access to create/update draft releases |
| `auto-merge.yml` | `contents: read` | Minimal read-only — actual merge operations use the GitHub App token |
| `cla.yml` | `contents: write`, `pull-requests: write`, `actions: read` | CLA Assistant needs to push to the signatures branch, comment on PRs, and read workflow context |

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by OpenCode.</sub>