### PR TITLE
chore: group dependabot updates for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       timezone: "Europe/Berlin"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds a `groups` configuration to the Dependabot config so that all GitHub Actions dependency updates are combined into a single PR instead of individual PRs per action.
- This reduces PR noise and makes it easier to review and merge action updates together.

---
<sub>The changes and the PR were generated by OpenCode.</sub>