### PR TITLE
fix: add pull-requests: read permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
### Type of Change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Follow-up to #59. The reusable release drafter workflow (`template_release_drafter.yml`) internally requests `pull-requests: read` to read PR data for generating release notes. Without this permission granted by the caller, the nested job is denied access:

```
Error calling workflow 'Staffbase/gha-workflows/...template_release_drafter.yml'.
The nested job 'update_release_draft' is requesting 'pull-requests: read',
but is only allowed 'pull-requests: none'.
```

This adds `pull-requests: read` to the `permissions` block in `release.yml`.

### Checklist

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](../blob/main/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by OpenCode.</sub>